### PR TITLE
replace parseQuery() with getOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function (content) {
         this[__dirname]();
     }
 
-    const query = loaderUtils.parseQuery(this.query);
+    const query = loaderUtils.getOptions(this);
 
     if (!query.q) {
         throw new Error('proxy-loader requires "q" query parameter');


### PR DESCRIPTION
This fixes Error output: `loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56`